### PR TITLE
Replacing underscores by dashes in DNS convention.

### DIFF
--- a/docs/code_conventions.txt
+++ b/docs/code_conventions.txt
@@ -22,7 +22,7 @@ Prefer .txt files instead of markdown.
 
 ## DNS
 
-Use underscores for multi-word accounts.
+Use dashes for multi-word accounts.
 
 * user domain : john-smith.zfs.rent
 * VNC domain  : john-smith.vnc.zfs.rent


### PR DESCRIPTION
DNS examples were using dashes so I assumed that was the intended phrashing.